### PR TITLE
Make offset lag metric periodic

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -276,6 +276,7 @@ public class IngestionDelayTracker {
         // Do not update the metrics for the segment that is marked to be ignored.
         return v;
       }
+
       if (v == null) {
         // Add metric when we start tracking a partition. Only publish the metric if supported by the stream.
         if (ingestionTimeMs > 0) {
@@ -291,18 +292,32 @@ public class IngestionDelayTracker {
           _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
               () -> getPartitionIngestionOffsetLag(partitionId));
         }
-
         if (currentOffset != null) {
           _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
               ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET, () -> getPartitionIngestionConsumingOffset(partitionId));
         }
-
         if (latestOffset != null) {
           _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
               ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET, () -> getPartitionIngestionUpstreamOffset(partitionId));
         }
+      } else {
+        // Install metrics if they were not present before
+        if (v._currentOffset == null && v._latestOffset == null && currentOffset != null && latestOffset != null) {
+          _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
+              () -> getPartitionIngestionOffsetLag(partitionId));
+          _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
+              ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET, () -> getPartitionIngestionConsumingOffset(partitionId));
+          _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
+              ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET, () -> getPartitionIngestionUpstreamOffset(partitionId));
+        }
       }
-      return new IngestionInfo(ingestionTimeMs, firstStreamIngestionTimeMs, currentOffset, latestOffset);
+
+      long newIngestionTime = ingestionTimeMs >= 0 ? ingestionTimeMs : (v != null ? v._ingestionTimeMs : ingestionTimeMs);
+      long newFirstStreamIngestionTime = firstStreamIngestionTimeMs >= 0 ? firstStreamIngestionTimeMs
+          : (v != null ? v._firstStreamIngestionTimeMs : firstStreamIngestionTimeMs);
+      StreamPartitionMsgOffset newCurrentOffset = currentOffset != null ? currentOffset : (v != null ? v._currentOffset : null);
+      StreamPartitionMsgOffset newLatestOffset = latestOffset != null ? latestOffset : (v != null ? v._latestOffset : null);
+      return new IngestionInfo(newIngestionTime, newFirstStreamIngestionTime, newCurrentOffset, newLatestOffset);
     });
 
     // If we are consuming we do not need to track this partition for removal.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -260,6 +260,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private final PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
   private final PartitionDedupMetadataManager _partitionDedupMetadataManager;
   private final BooleanSupplier _isReadyToConsumeData;
+  private final boolean _trackOffsetLag;
+  private final long _offsetLagMetricUpdatePeriodMs;
+  private final AtomicLong _lastOffsetLagMetricUpdateTimeMs = new AtomicLong(0L);
   private final MutableSegmentImpl _realtimeSegment;
   private volatile StreamPartitionMsgOffset _currentOffset; // Next offset to be consumed
   private volatile State _state;
@@ -1615,6 +1618,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _trackFilteredMessageOffsets = ingestionConfig != null && ingestionConfig.getStreamIngestionConfig() != null
         && ingestionConfig.getStreamIngestionConfig().isTrackFilteredMessageOffsets();
     _parallelSegmentConsumptionPolicy = getParallelConsumptionPolicy();
+    _trackOffsetLag = indexLoadingConfig.isRealtimeOffsetLagMetricEnabled();
+    _offsetLagMetricUpdatePeriodMs = indexLoadingConfig.getRealtimeOffsetLagMetricUpdatePeriodMs();
 
     String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     // TODO Validate configs
@@ -1965,14 +1970,21 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   private void updateIngestionMetrics(RowMetadata metadata) {
     if (metadata != null) {
-      try {
-        StreamPartitionMsgOffset latestOffset = fetchLatestStreamOffset(5000, true);
-        _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId,
-            metadata.getRecordIngestionTimeMs(), metadata.getFirstStreamRecordIngestionTimeMs(), metadata.getOffset(),
-            latestOffset);
-      } catch (Exception e) {
-        _segmentLogger.warn("Failed to fetch latest offset for updating ingestion delay", e);
+      StreamPartitionMsgOffset latestOffset = null;
+      if (_trackOffsetLag) {
+        long now = System.currentTimeMillis();
+        if (now - _lastOffsetLagMetricUpdateTimeMs.get() >= _offsetLagMetricUpdatePeriodMs) {
+          try {
+            latestOffset = fetchLatestStreamOffset(5000, true);
+          } catch (Exception e) {
+            _segmentLogger.warn("Failed to fetch latest offset for updating ingestion delay", e);
+          }
+          _lastOffsetLagMetricUpdateTimeMs.set(now);
+        }
       }
+      _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId,
+          metadata.getRecordIngestionTimeMs(), metadata.getFirstStreamRecordIngestionTimeMs(), metadata.getOffset(),
+          latestOffset);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -333,6 +333,14 @@ public class IngestionDelayTrackerTest {
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionUpstreamOffset(partition0), 200);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionConsumingOffset(partition0), 150);
 
+    // Update without latest offset should not change lag metrics
+    msgOffset0 = new LongMsgOffset(180);
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset0,
+        null);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 20);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionUpstreamOffset(partition0), 200);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionConsumingOffset(partition0), 180);
+
     ingestionDelayTracker.shutdown();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -74,6 +74,8 @@ public class IndexLoadingConfig {
   private String _segmentStoreURI;
   private String _segmentDirectoryLoader;
   private Map<String, Map<String, String>> _instanceTierConfigs;
+  private boolean _realtimeOffsetLagMetricEnabled = true;
+  private long _realtimeOffsetLagMetricUpdatePeriodMs = 60_000L;
 
   // Initialized by table config and schema
   private List<String> _sortedColumns = Collections.emptyList();
@@ -164,6 +166,9 @@ public class IndexLoadingConfig {
 
     Map<String, Map<String, String>> tierConfigs = _instanceDataManagerConfig.getTierConfigs();
     _instanceTierConfigs = tierConfigs != null ? tierConfigs : Map.of();
+
+    _realtimeOffsetLagMetricEnabled = _instanceDataManagerConfig.isRealtimeOffsetLagMetricEnabled();
+    _realtimeOffsetLagMetricUpdatePeriodMs = _instanceDataManagerConfig.getRealtimeOffsetLagMetricUpdatePeriodMs();
   }
 
   private void extractFromTableConfigAndSchema() {
@@ -300,6 +305,14 @@ public class IndexLoadingConfig {
   public String getSegmentDirectoryLoader() {
     return StringUtils.isNotBlank(_segmentDirectoryLoader) ? _segmentDirectoryLoader
         : SegmentDirectoryLoaderRegistry.DEFAULT_SEGMENT_DIRECTORY_LOADER_NAME;
+  }
+
+  public boolean isRealtimeOffsetLagMetricEnabled() {
+    return _realtimeOffsetLagMetricEnabled;
+  }
+
+  public long getRealtimeOffsetLagMetricUpdatePeriodMs() {
+    return _realtimeOffsetLagMetricUpdatePeriodMs;
   }
 
   public PinotConfiguration getSegmentDirectoryConfigs() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -112,6 +112,12 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public static final String UPLOAD_SEGMENT_TO_DEEP_STORE = "segment.upload.to.deep.store";
   public static final boolean DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE = false;
 
+  private static final String OFFSET_LAG_METRIC_ENABLED = "realtime.ingestion.offset.lag.metric.enabled";
+  private static final boolean DEFAULT_OFFSET_LAG_METRIC_ENABLED = true;
+  private static final String OFFSET_LAG_METRIC_UPDATE_PERIOD_MS =
+      "realtime.ingestion.offset.lag.metric.update.period.ms";
+  private static final long DEFAULT_OFFSET_LAG_METRIC_UPDATE_PERIOD_MS = 60_000L;
+
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
   private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
   private static final int DEFAULT_DELETED_TABLES_CACHE_TTL_MINUTES = 60;
@@ -316,5 +322,16 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public boolean isUploadSegmentToDeepStore() {
     return _serverConfig.getProperty(UPLOAD_SEGMENT_TO_DEEP_STORE, DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE);
+  }
+
+  @Override
+  public boolean isRealtimeOffsetLagMetricEnabled() {
+    return _serverConfig.getProperty(OFFSET_LAG_METRIC_ENABLED, DEFAULT_OFFSET_LAG_METRIC_ENABLED);
+  }
+
+  @Override
+  public long getRealtimeOffsetLagMetricUpdatePeriodMs() {
+    return _serverConfig.getProperty(OFFSET_LAG_METRIC_UPDATE_PERIOD_MS,
+        DEFAULT_OFFSET_LAG_METRIC_UPDATE_PERIOD_MS);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -86,4 +86,18 @@ public interface InstanceDataManagerConfig {
   Map<String, Map<String, String>> getTierConfigs();
 
   boolean isUploadSegmentToDeepStore();
+
+  /**
+   * Returns whether realtime ingestion offset lag metric is enabled.
+   */
+  default boolean isRealtimeOffsetLagMetricEnabled() {
+    return true;
+  }
+
+  /**
+   * Returns the update period for realtime ingestion offset lag metric in milliseconds.
+   */
+  default long getRealtimeOffsetLagMetricUpdatePeriodMs() {
+    return 60_000L;
+  }
 }


### PR DESCRIPTION
## Summary
- update IngestionDelayTracker to keep previous offsets when latest offset not provided
- periodically update offset lag metric in RealtimeSegmentDataManager
- expose offset lag metric period and enable flags in config
- add tests for partial offset updates

## Testing
- `./mvnw test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*